### PR TITLE
Added doctype option for jade

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -132,7 +132,7 @@ module.exports = function parser(file, options) {
     assetFiles = assetFiles.replace(/(\n*)$/, '');
 
     if ('jade' === opts.type) {
-      assetFiles = jade.render(assetFiles);
+      assetFiles = jade.render(assetFiles,{doctype: 'html'});
     }
 
     // Indent content.


### PR DESCRIPTION
To be usable with angular the jade renderer needs to be invoked with doctype = 'html' options. See here for a discussion: https://github.com/pugjs/jade/issues/1180