### PR TITLE
feat(templateFunction): powerful flexibility with templateFunction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ defaults = {
   useRelativePaths: false     // Use components relative assset paths
   removeLineBreaks: false     // Content will be included as one line
   templateExtension: '.html', // Update according to your file extension
+  templateFunction: function ..., // If using a function instead of a string for `templateUrl`, pass a reference to that function here
   templatePreprocessor: function ...,
   stylePreprocessor:  function ...
 };

--- a/parser.js
+++ b/parser.js
@@ -18,9 +18,14 @@ var defaults = {
   useRelativePaths: false,
   removeLineBreaks: false,
   templateExtension: '.html',
+  templateFunction: defaultFunction,
   templateProcessor: defaultProcessor,
   styleProcessor: defaultProcessor
 };
+
+function defaultFunction(path) {
+  return path;
+}
 
 function defaultProcessor(path, file) {
   return file;
@@ -118,7 +123,16 @@ module.exports = function parser(file, options) {
   }
 
   function replaceFrag() {
-    var _urls = eval('({' + frag + '})')[opts.prop_url];
+    var _urls;
+    var fnIndex = frag.indexOf('(');
+    if (fnIndex > -1 && opts.templateFunction) {
+      // using template function
+      // replace with opts.templateFunction
+      _urls = opts.templateFunction(frag.substring(fnIndex + 2, frag.length - 1));
+    } else {
+      _urls = eval('({' + frag + '})')[opts.prop_url];  
+    }
+    
     var urls  = isarray(_urls) ? _urls : [_urls];
     var line  = lines[start_line_idx];
     var indentation = /^\s*/.exec(line)[0];

--- a/test/fixtures/result_expected_function.js
+++ b/test/fixtures/result_expected_function.js
@@ -1,0 +1,15 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `),
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_function.js
+++ b/test/fixtures/templates_function.js
@@ -1,0 +1,9 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  templateUrl: viewFunction('./app.html'),
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,9 @@ var fs = require('fs');
 var File = require('vinyl');
 var inline = require('../index');
 var join = require('path').join;
+var viewFunction = function (path) {
+  return path;
+};
 
 
 describe('gulp-inline-ng2-template', function () {
@@ -36,6 +39,21 @@ describe('gulp-inline-ng2-template', function () {
     };
 
     runTest(paths, { base: 'test/fixtures', removeLineBreaks: true }, done);
+  });
+  
+  it('should work with default config and templateUrl as a function', function (done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_function.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_function.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_function.js'
+    };
+    
+    var OPTIONS = {
+      base: 'test/fixtures',
+      templateFunction: viewFunction
+    };
+
+    runTest(paths, OPTIONS, done);
   });
 
   it('should work with templates and styles processors', function (done) {


### PR DESCRIPTION
This allows for powerful flexibility in how `templateUrl` can be processed.
One example can be seen in the following; Using the same component for multiple platforms by using a type of view broker to process the path of the template based upon certain static app configuration settings:

This component uses a custom decorator:
https://github.com/NathanWalker/angular2-seed-advanced/blob/development/src/components/app/app.ts#L12

Which always processes the `templateUrl` with a `ViewBroker` setup:
https://github.com/NathanWalker/angular2-seed-advanced/blob/development/src/frameworks/app.framework/core/decorators/utils.ts#L29

The `ViewBroker` can then alter the path of the `templateUrl` based upon certain platform targets:
https://github.com/NathanWalker/angular2-seed-advanced/blob/development/src/frameworks/app.framework/core/services/view-broker.ts

Adding this `templateFunction` option will allow usage of this plugin to test this type of powerful setup.

@ludohenin I need your help tweaking one aspect of this. Although this works and passes all tests, there is one minor error in my implementation here:
https://github.com/NathanWalker/gulp-inline-ng2-template/blob/template-function/test/fixtures/result_expected_function.js#L12

The `)` should not be there. If you could assist in figuring out how to fix that, then this will be good to go.