### PR TITLE
fix(parser): tighten up start_pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ node_modules
 .lock-wscript
 .tsdrc
 
-test/fixtures/result_actual_*
+test/fixtures/result_actual*

--- a/parser.js
+++ b/parser.js
@@ -32,7 +32,7 @@ var htmlOptions = function (opts) {
     type: 'html',
     prop_url: 'templateUrl',
     prop: 'template',
-    start_pattern: /templateUrl.*/,
+    start_pattern: /templateUrl:.*/,
     end_pattern: new RegExp('.*\\' + opts.templateExtension + '\s*(\'\\)|\')|.*\\' + opts.templateExtension + '\s*("\\)|")'),
     oneliner_pattern: new RegExp('templateUrl.*(\\' + opts.templateExtension + '\s*(\'\\)|\')|\\' + opts.templateExtension + 's*("\\)|"))')
   };
@@ -43,7 +43,7 @@ var cssOptions = function () {
     type: 'css',
     prop_url: 'styleUrls',
     prop: 'styles',
-    start_pattern: /styleUrls.*/,
+    start_pattern: /styleUrls:.*/,
     end_pattern: /.*]/,
     oneliner_pattern: /styleUrls(.*?)]/
   };


### PR DESCRIPTION
This prevents issues that can occur when certain setups use decorators and other extensible options.
In the advanced seed, the decorator would pass the pattern simply because it contained `styleUrls` in it and this would end up as `frag`:
```
styleUrls;    }        config.directives = config.directives ? config.directives.concat(DIRECTIVES) : DIRECTIVES;    config.pipes = config.pipes ? config.pipes.concat(PIPES) : PIPES;    config.host = config.host || {};        if (config.encapsulation) {      config.encapsulation = config.encapsulation;    }    return config;  }    public static annotateComponent(cls, config: any = {}, opts?: any) {    let annotations = _reflect.getMetadata('annotations', cls) || []
```

Coming from the decorator here:
https://github.com/NathanWalker/angular2-seed-advanced/blob/development/src/frameworks/core.framework/decorators/utils.ts#L36-L57

Including `:` will tighten up the pattern. This fix has been verified in the advanced seed :+1: 
Let me know if you have any concerns/questions. 


