### PR TITLE
Ensure backticks in html/css files are unescaped.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -147,8 +147,8 @@ module.exports = function parser(file, options) {
       assetFiles += file;
     });
 
-    // Trim trailing line breaks.
-    assetFiles = assetFiles.replace(/(\n*)$/, '');
+    // Trim trailing line breaks and unescape any backtick characters present.
+    assetFiles = assetFiles.replace(/(\n*)$/, '').replace(/`/g, '\\`');
 
     // We don't need indentation if we are going to insert it as one line
     if(!opts.removeLineBreaks) {

--- a/test/fixtures/app_unescaped.css
+++ b/test/fixtures/app_unescaped.css
@@ -1,0 +1,7 @@
+.test {
+  color: red;
+}
+/* This is a comment with `backticks` in it. */
+smile:before {
+  content: "\000B";
+}

--- a/test/fixtures/app_unescaped.html
+++ b/test/fixtures/app_unescaped.html
@@ -1,0 +1,9 @@
+<h1>Test</h1>
+<!-- This is a comment with
+```javascript
+multipleBackticks()
+```
+in it -->
+<p>
+  Test
+</p>

--- a/test/fixtures/result_expected_unescaped.js
+++ b/test/fixtures/result_expected_unescaped.js
@@ -1,0 +1,28 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  template: `
+    <h1>Test</h1>
+    <!-- This is a comment with
+    \`\`\`javascript
+    multipleBackticks()
+    \`\`\`
+    in it -->
+    <p>
+      Test
+    </p>
+  `,
+  styles: [`
+    .test {
+      color: red;
+    }
+    /* This is a comment with \`backticks\` in it. */
+    smile:before {
+      content: "\000B";
+    }
+  `],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_unescaped.js
+++ b/test/fixtures/templates_unescaped.js
@@ -1,0 +1,10 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  templateUrl: './app_unescaped.html',
+  styleUrls: ['./app_unescaped.css'],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/test.js
+++ b/test/test.js
@@ -40,14 +40,14 @@ describe('gulp-inline-ng2-template', function () {
 
     runTest(paths, { base: 'test/fixtures', removeLineBreaks: true }, done);
   });
-  
+
   it('should work with default config and templateUrl as a function', function (done) {
     var paths = {
       TEST_FILE      : './test/fixtures/templates_function.js',
       RESULT_EXPECTED: './test/fixtures/result_expected_function.js',
       RESULT_ACTUAL  : './test/fixtures/result_actual_function.js'
     };
-    
+
     var OPTIONS = {
       base: 'test/fixtures',
       templateFunction: viewFunction
@@ -76,6 +76,16 @@ describe('gulp-inline-ng2-template', function () {
     };
 
     runTest(paths, OPTIONS, done);
+  });
+
+  it('should work with templates and styles with backticks in them', function(done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_unescaped.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_unescaped.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_unescaped.js'
+    };
+
+    runTest(paths, { base: 'test/fixtures' }, done);
   });
 });
 


### PR DESCRIPTION
This commit ensures that backtick characters in external files are
properly unescaped when being inlined. Backticks can appear in html/css
files in certain situations such as markdown comment blocks with code
snippets wrapped in backticks, e.g. /* This is `some code.` */