### PR TITLE
add support for scaffolding out components without backing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ defaults = {
   templateExtension: '.html', // Update according to your file extension
   templateFunction: false,    // If using a function instead of a string for `templateUrl`, pass a reference to that function here
   templateProcessor: function ...,
-  styleProcessor:  function ...
+  styleProcessor:  function ...,
+  supportNonExistentFiles: false // If html or css file do not exist just return empty content
 };
 ```
 

--- a/parser.js
+++ b/parser.js
@@ -20,7 +20,8 @@ var defaults = {
   templateExtension: '.html',
   templateFunction: false,
   templateProcessor: defaultProcessor,
-  styleProcessor: defaultProcessor
+  styleProcessor: defaultProcessor,
+  supportNonExistentFiles: false
 };
 
 function defaultProcessor(path, file) {
@@ -186,6 +187,10 @@ module.exports = function parser(file, options) {
       var absPath = opts.useRelativePaths ? join(dirname(file.path), filepath)
                                           : join(process.cwd(), opts.base, filepath);
 
+      if(opts.supportNonExistentFiles && !fs.existsSync(absPath)) {
+        return '';  
+      }
+      
       return fs.readFileSync(absPath)
         .toString()
         .replace(/\r/g, '')

--- a/test/fixtures/result_expected_nonexistent_files.js
+++ b/test/fixtures/result_expected_nonexistent_files.js
@@ -1,0 +1,14 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  template: `
+
+  `,
+  styles: [`
+
+  `],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_nonexistent_files.js
+++ b/test/fixtures/templates_nonexistent_files.js
@@ -1,0 +1,10 @@
+// TEST_1
+@Component({
+  selector: 'app'
+})
+@View({
+  templateUrl: './app_nonexistent.html',
+  styleUrls: ['./app_nonexistent.stylus', './common_nonexistent.stylus'],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,16 @@ describe('gulp-inline-ng2-template', function () {
 
     runTest(paths, { base: 'test/fixtures' }, done);
   });
+  
+  it('should work when templateUrl and styleUrl files do not exist', function(done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_nonexistent_files.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_nonexistent_files.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_nonexistent_files.js'
+    };
+
+    runTest(paths, { supportNonExistentFiles: true }, done);
+  });
 });
 
 


### PR DESCRIPTION
adding this support allows for scaffolding out components with empty sass files:
when sass files are empty the sass compiler does not output a CSS file and the component points to a CSS file that does not exist, with this change an non-existent CSS file is no longer a problem