### PR TITLE
Added a customFilePath properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Very convenient to unit test your component or bundle your components/applicatio
 
 __note:__
 
+* 1.1.5 adds `customFilePath` option
 * 1.1.4 adds `supportNonExistentFiles` option
 * 1.1.0 adds templateFunction when templateUrl is a function
 * 1.0.0 - __Breaking changes__
@@ -42,6 +43,7 @@ defaults = {
   templateFunction: false,    // If using a function instead of a string for `templateUrl`, pass a reference to that function here
   templateProcessor: function (ext, file) {/* ... */},
   styleProcessor: function (ext, file) {/* ... */},
+  customFilePath: function(ext, file) {/* ... */},
   supportNonExistentFiles: false // If html or css file do not exist just return empty content
 };
 ```
@@ -76,6 +78,21 @@ Inside your component: `templateUrl: templateFunc('app.html')`
 templateFunction: function (filename) {
   // ...
   return newFilename;
+}
+```
+
+## CustomFilePath configuration
+
+```typescript
+/**
+ *  Custom function name call signature and type return
+ *
+ * @Param{String}   file extension (type)
+ * @Param{String}   file path
+ * @Return{String}  returned file path updated
+ */
+function customFilePath(ext, file) {
+  return file;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline-ng2-template",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Gulp plugin to inline HTML and CSS into Angular 2 component views",
   "repository": "https://github.com/ludohenin/gulp-inline-ng2-template.git",
   "main": "index.js",

--- a/parser.js
+++ b/parser.js
@@ -21,11 +21,16 @@ var defaults = {
   templateFunction: false,
   templateProcessor: defaultProcessor,
   styleProcessor: defaultProcessor,
+  customFilePath: defaultSytlePath,
   supportNonExistentFiles: false
 };
 
 function defaultProcessor(path, file) {
   return file;
+}
+
+function defaultSytlePath(path) {
+  return path;
 }
 
 var htmlOptions = function (opts) {
@@ -190,6 +195,8 @@ module.exports = function parser(file, options) {
       if(opts.supportNonExistentFiles && !fs.existsSync(absPath)) {
         return '';  
       }
+      
+      absPath = opts.customFilePath(absPath);
       
       return fs.readFileSync(absPath)
         .toString()

--- a/parser.js
+++ b/parser.js
@@ -21,7 +21,7 @@ var defaults = {
   templateFunction: false,
   templateProcessor: defaultProcessor,
   styleProcessor: defaultProcessor,
-  customFilePath: defaultSytlePath,
+  customFilePath: defaultCustomFilePath,
   supportNonExistentFiles: false
 };
 
@@ -29,7 +29,7 @@ function defaultProcessor(path, file) {
   return file;
 }
 
-function defaultSytlePath(path) {
+function defaultCustomFilePath(ext, path) {
   return path;
 }
 
@@ -196,7 +196,8 @@ module.exports = function parser(file, options) {
         return '';  
       }
       
-      absPath = opts.customFilePath(absPath);
+      var ext = /\.[0-9a-z]+$/i.exec(absPath);
+      absPath = opts.customFilePath(ext, absPath);
       
       return fs.readFileSync(absPath)
         .toString()


### PR DESCRIPTION
Hi,
i've not understand how to use this plugin when i use sass.
for that i've added a customFilePath that permits to change the path of each file...

like that i can do that

````
gulp.task('sass', function () {
    return gulp.src('./src/**/*.scss')
        .pipe(plugins.sourcemaps.init())
        .pipe(plugins.sass({
            /*importer: moduleImporter(),*/
            includePaths: [
                'src/',
                'node_modules/'
            ]
        }).on('error', plugins.sass.logError))
        .pipe(plugins.autoprefixer(autoprefixerSettings))
        .pipe(plugins.sourcemaps.write('.', { sourceRoot: '/../src' }))
        .pipe(gulp.dest('./public'))
        .pipe(browserSync.stream());
});

gulp.task('build:ts', ['sass'], function () {
    var tsResult = tsProject.src()
    .pipe(plugins.inlineNg2Template({
        base: '/src',
        useRelativePaths: true,
        removeLineBreaks: true,
        customFilePath: function (path) {
            if (path.indexOf('.css', path.length - '.css'.length) !== -1) {
                return path.replace('/src/', '/public/');
            }
            return path;
        }
    })).pipe(plugins.typescript(tsProject));

    //return tsResult.js.pipe(gulp.dest('./build'));

    return merge([
        tsResult.js.pipe(gulp.dest('./build')),
        tsResult.dts.pipe(gulp.dest('./build'))
    ]);
});
````

without inlineNg2Template complaining about not finding the path of the css file into the src folder