### PR TITLE
Add support for quote marks on both simple and templateFunction modes.

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -161,7 +161,28 @@ module.exports = function parser(file, options) {
     var fnIndex = frag.indexOf('(');
     if (fnIndex > -1 && opts.templateFunction) {
       // Using template function.
-      _urls = opts.templateFunction(/'(.*)'/.exec(frag)[1]);
+
+      // Check if templateFunction uses single quotes or quote marks.
+      var urlRegex = frag.indexOf('\'') != -1 ? /'(.*)'/ : /"(.*)"/;
+
+      // Need to clone the regex, since exec() keeps the lastIndex.
+      var testRegex = clone(urlRegex), lineCheck = clone(urlRegex);
+      var hasMultiline = testRegex.exec(frag)[1];
+      
+      if (hasMultiline && hasMultiline.lastIndexOf(",") != -1) {
+        _urls = [];
+        // Split fragments that kept comma.
+        var files = frag.split(",");
+        
+        // Populate url list, using the return value of the templateFunction.
+        for (var i = 0; i < files.length; i++) {
+          _urls.push(opts.templateFunction(lineCheck.exec(files[i])[1]));
+        }
+      }
+      
+      if (!_urls) {
+        _urls = opts.templateFunction(urlRegex.exec(frag)[1]);
+      }
     } else {
       _urls = eval('({' + frag + '})')[opts.prop_url];
     }

--- a/test/fixtures/result_expected_quotemark.js
+++ b/test/fixtures/result_expected_quotemark.js
@@ -1,0 +1,21 @@
+// TEST 1
+@Component({
+  selector: "app",
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `,
+  styles: [`
+    .test {
+      color: red;
+    }
+    smile:before {
+      content: "\000B";
+    }
+  `],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/result_expected_quotemark_function.js
+++ b/test/fixtures/result_expected_quotemark_function.js
@@ -1,0 +1,24 @@
+// TEST 1
+@Component({
+  selector: "app",
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `,
+  styles: [`
+    .test {
+      color: red;
+    }
+    smile:before {
+      content: "\000B";
+    }
+    .common {
+      color: grey;
+    }
+  `],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_quotemark.js
+++ b/test/fixtures/templates_quotemark.js
@@ -1,0 +1,8 @@
+// TEST 1
+@Component({
+  selector: "app",
+  templateUrl: "./app.html",
+  styleUrls: ["./app.css"],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_quotemark_function.js
+++ b/test/fixtures/templates_quotemark_function.js
@@ -1,0 +1,10 @@
+// TEST 1
+@Component({
+  selector: "app",
+  templateUrl: viewFunction("./app.html"),
+  styleUrls: [
+    viewFunction("./app.css"),
+    viewFunction("./common.css")],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,31 @@ describe('gulp-inline-ng2-template', function () {
 
     runTest(paths, { supportNonExistentFiles: true }, done);
   });
+
+  it('should work with different quote marks', function (done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_quotemark.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_quotemark.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_quotemark.js'
+    };
+
+    runTest(paths, { base: 'test/fixtures' }, done);
+  });
+
+  it('should work with template function and different quote marks', function (done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_quotemark_function.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_quotemark_function.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_quotemark_function.js'
+    };
+
+    var OPTIONS = { 
+      base: 'test/fixtures',
+      templateFunction: viewFunction
+    };
+
+    runTest(paths, OPTIONS, done);
+  });
 });
 
 


### PR DESCRIPTION
Hi, I was having a very strange error when using double quote marks on the URLs (using a `templateFunction`) for both `templateUrl` and `styleUrls`.

````
Uncaught TypeError: Cannot read property '1' of null
      at replaceFrag (parser.js:164:56)
      at getFragment (parser.js:149:5)
      at parser.js:109:13
```
Adding a check for single or double quote marks on the fragment did the trick.

Feel free to provide feedback, it's my first contribution to this project. 🎆 