### PR TITLE
Fixes #44: Add Support for Backticks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.12"
+  - "4.5"
 
 sudo: false
 

--- a/parser.js
+++ b/parser.js
@@ -41,8 +41,8 @@ var htmlOptions = function (opts) {
     prop_url: 'templateUrl',
     prop: 'template',
     start_pattern: /templateUrl\s*:.*/,
-    end_pattern: new RegExp('.*\\' + opts.templateExtension + '\s*(\'\\)|\')|.*\\' + opts.templateExtension + '\s*("\\)|")'),
-    oneliner_pattern: new RegExp('templateUrl.*(\\' + opts.templateExtension + '\s*(\'\\)|\')|\\' + opts.templateExtension + 's*("\\)|"))')
+    end_pattern: new RegExp('.*\\' + opts.templateExtension + '\s*(\'\\)|\')|.*\\' + opts.templateExtension + '\s*("\\)|")|.*\\' + opts.templateExtension + '\s*(`\\)|`)'),
+    oneliner_pattern: new RegExp('templateUrl.*(\\' + opts.templateExtension + '\s*(\'\\)|\')|\\' + opts.templateExtension + 's*("\\)|")|\\' + opts.templateExtension + 's*(`\\)|`))')
   };
 };
 
@@ -127,7 +127,7 @@ module.exports = function parser(file, options) {
       }
       if (opts.end_pattern.test(line)) {
         // Match end pattern without start.
-        // end_line_idx is till equal to previous loop turn value.
+        // end_line_idx is still equal to previous loop turn value.
         if (start_line_idx <= end_line_idx) return;
         end_line_idx = i;
       }

--- a/test/fixtures/result_expected_backtick.js
+++ b/test/fixtures/result_expected_backtick.js
@@ -1,0 +1,21 @@
+// TEST 1
+@Component({
+  selector: "app",
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `,
+  styles: [`
+    .test {
+      color: red;
+    }
+    smile:before {
+      content: "\000B";
+    }
+  `],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/fixtures/templates_backtick.js
+++ b/test/fixtures/templates_backtick.js
@@ -1,0 +1,8 @@
+// TEST 1
+@Component({
+  selector: "app",
+  templateUrl: `./app.html`,
+  styleUrls: [`./app.css`],
+  directives: [CORE_DIRECTIVES]
+})
+export class App {}

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,16 @@ describe('gulp-inline-ng2-template', function () {
     runTest(paths, { base: 'test/fixtures' }, done);
   });
 
+  it('should work with backticks', function (done) {
+    var paths = {
+      TEST_FILE      : './test/fixtures/templates_backtick.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_backtick.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_backtick.js'
+    };
+
+    runTest(paths, { base: 'test/fixtures' }, done);
+  });
+
   it('should work with template function and different quote marks', function (done) {
     var paths = {
       TEST_FILE      : './test/fixtures/templates_quotemark_function.js',


### PR DESCRIPTION
Calling it backticks in the tests instead of template strings seemed to make more sense, once I saw the quote related tests. (I've also seen them called "[template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)"?)

This would fix the issue brought up here: https://github.com/ludohenin/gulp-inline-ng2-template/issues/44