### PR TITLE
Add option to remove `moduleId` after inlining templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ defaults = {
 };
 ```
 
-#### Component.moduleId
-
-
-
 ### Processors configuration
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This plugin uses the [ES6 template strings](https://github.com/lukehoban/es6feat
 
 Very convenient to unit test your component or bundle your components/application (avoid extra HTTP request and keeps your source clean).
 
+By aggressively inlining templates, component library authors can ensure that their library is
+compatible with all deployment methods (SystemJS, Webpack, etc.) and avoid problems associated
+with setting `Component.moduleId` on published components.
+
+
 __note:__
 
 * 4.0.0 -
@@ -65,8 +70,9 @@ defaults = {
   base: '/',                  // Angular2 application base folder
   target: 'es6',              // Can swap to es5
   indent: 2,                  // Indentation (spaces)
-  useRelativePaths: false     // Use components relative assset paths
-  removeLineBreaks: false     // Content will be included as one line
+  useRelativePaths: false,    // Use components relative assset paths
+  removeLineBreaks: false,    // Content will be included as one line
+  removeModuleId: false,      // Remove the `moduleId` key from component definition after inlining styles
   templateExtension: '.html', // Update according to your file extension
   templateFunction: false,    // If using a function instead of a string for `templateUrl`, pass a reference to that function here
   templateProcessor: function (path, ext, file, callback) {/* ... */},
@@ -75,6 +81,10 @@ defaults = {
   supportNonExistentFiles: false // If html or css file do not exist just return empty content
 };
 ```
+
+#### Component.moduleId
+
+
 
 ### Processors configuration
 

--- a/test/fixtures/result_expected.js
+++ b/test/fixtures/result_expected.js
@@ -1,6 +1,7 @@
 // TEST_1
 @Component({
-  selector: 'app'
+  selector: 'app',
+  moduleId: module.id
 })
 @View({
   template: `

--- a/test/fixtures/result_expected_one_line.js
+++ b/test/fixtures/result_expected_one_line.js
@@ -1,6 +1,7 @@
 // TEST_1
 @Component({
-  selector: 'app'
+  selector: 'app',
+  moduleId: module.id
 })
 @View({
   template: `<h1>Test</h1>  <p>   Test </p>`,

--- a/test/fixtures/result_expected_remove_module_id.js
+++ b/test/fixtures/result_expected_remove_module_id.js
@@ -1,0 +1,37 @@
+// TEST 1
+@Component({
+  selector: 'standard-module-id',
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `
+})
+export class StandardModuleId {}
+
+// TEST 2
+@Component({
+  selector: 'multiline-module-id',
+  template: `
+    <h1>Test</h1>
+
+    <p>
+      Test
+    </p>
+  `
+})
+export class MultilineModuleId {}
+
+// TEST 3
+@Component({
+  selector: 'module-id-no-trailing-comma',
+})
+export class LastPropertyModuleId {}
+
+// TEST 4
+@Component({
+  selector: 'string module id',
+})
+export class StringModuleId {}

--- a/test/fixtures/templates.js
+++ b/test/fixtures/templates.js
@@ -1,6 +1,7 @@
 // TEST_1
 @Component({
-  selector: 'app'
+  selector: 'app',
+  moduleId: module.id
 })
 @View({
   templateUrl: './app.html',

--- a/test/fixtures/templates_remove_module_id.js
+++ b/test/fixtures/templates_remove_module_id.js
@@ -1,0 +1,31 @@
+// TEST 1
+@Component({
+  selector: 'standard-module-id',
+  moduleId: module.id,
+  templateUrl: 'app.html'
+})
+export class StandardModuleId {}
+
+// TEST 2
+@Component({
+  selector: 'multiline-module-id',
+  moduleId:
+      module.id
+  ,
+  templateUrl: 'app.html'
+})
+export class MultilineModuleId {}
+
+// TEST 3
+@Component({
+  selector: 'module-id-no-trailing-comma',
+  moduleId: module.id
+})
+export class LastPropertyModuleId {}
+
+// TEST 4
+@Component({
+  selector: 'string module id',
+  moduleId: 'path/to/module.ts'
+})
+export class StringModuleId {}

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,22 @@ describe('gulp-inline-ng2-template', function () {
     runTest(paths, OPTIONS, done);
   });
 
+  it('should work with default config and remove the module id', function (done) {
+    var paths = {
+      TEST_FILE      :'./test/fixtures/templates_remove_module_id.js',
+      RESULT_EXPECTED: './test/fixtures/result_expected_remove_module_id.js',
+      RESULT_ACTUAL  : './test/fixtures/result_actual_remove_module_id.js'
+    };
+
+    var OPTIONS = {
+      base: 'test/fixtures',
+      removeModuleId: true
+    };
+
+    debugger;
+    runTest(paths, OPTIONS, done);
+  });
+
   it('should work with templates and styles processors', function (done) {
     var paths = {
       TEST_FILE      : './test/fixtures/templates_processors.js',
@@ -161,6 +177,8 @@ describe('gulp-inline-ng2-template', function () {
 
     runTest(paths, OPTIONS, done);
   });
+
+
 
   it('should emit the "error" event to the stream if a templateProcessor calls the callback with an error', function( done ) {
     var jsFile = createFile('./test/fixtures/templates.js');


### PR DESCRIPTION
PR associated with #80. 

Tried to match the code style used in the library, don't know how successful I was.

Feature is 100% backwards compatible. 